### PR TITLE
Add NODE_ENV=production to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ COPY --from=0 /usr/build/package-lock.json ./
 COPY --from=0 /usr/build/node_modules ./node_modules
 
 EXPOSE 3000
+ENV NODE_ENV=production
 
 CMD ["node", "./dist/index.js"]


### PR DESCRIPTION
ensures there are no error stacktraces sent to client