### PR TITLE
Parse timestamp as unix timestamp

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -21,7 +21,7 @@ const createGeoTiffPublicationJob = (requestBody: any) => {
 
   const geotiffUrl = requestBody.payload.url;
 
-  const parsedTimeStamp = dayjs(requestBody.payload.predictionStartTime);
+  const parsedTimeStamp = dayjs.unix(requestBody.payload.predictionStartTime);
   if (!parsedTimeStamp.isValid()) {
     throw 'TimeStamp not valid';
   }


### PR DESCRIPTION
When using a job configuration like given in the readme, e.g.
```
{
 ....
    "payload": {
        "url": "http://nginx/sample.tif",
        "creationTime": 12345657687,
        "predictionStartTime": 16608229550000,
        "predictionEndTime": 16608229560000,
        "interval": 3600,
        "region": 0,
        "type": 0
    }
}
```

the job will be rejected, as the timestamps are not parsed as unix timestamps, while typecheck requires integers.
So i fixed that by correctly parsing unix timestamps.

@hblitza @JakobMiksch please review